### PR TITLE
Fix download button id on reset

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -352,7 +352,7 @@ function clearPreviousSession() {
     }
     
     // Reset download button
-    const downloadBtn = document.getElementById('download-image');
+    const downloadBtn = document.getElementById('download-image-btn');
     if (downloadBtn) {
         downloadBtn.classList.add('hidden');
     }


### PR DESCRIPTION
## Summary
- ensure the download image button hides properly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840752ebcdc83259be4edce3f3ce764