### PR TITLE
Remove redundant docs in utils

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -4,11 +4,6 @@
  */
 
 /**
- * Shows a toast notification to the user
- * @param {string} message - The message to display
- * @param {number} duration - Duration in milliseconds (default: 3000ms)
- */
-/**
  * Shows a success feedback on a button
  * @param {HTMLElement} button - The button element to show feedback on
  * @param {string} [customText] - Optional custom success text to display


### PR DESCRIPTION
## Summary
- clean up js/utils.js comment block

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840752f37ec83259c8d7d48584b3d33