### PR TITLE
Add Jest with simple URL utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "jest"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -14,6 +15,7 @@
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "jest": "^29.6.1"
   }
 }

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,15 @@
+import { formatUrl } from '../js/utils.js';
+
+describe('formatUrl', () => {
+  test('adds https:// to URLs without scheme', () => {
+    expect(formatUrl('example.com')).toBe('https://example.com');
+  });
+
+  test('returns http URL unchanged', () => {
+    expect(formatUrl('http://example.com')).toBe('http://example.com');
+  });
+
+  test('returns https URL unchanged', () => {
+    expect(formatUrl('https://example.com')).toBe('https://example.com');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependency and test script
- create simple tests for `formatUrl`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840753037488325b2f57558f5ed5f09